### PR TITLE
Fixed http.py for 3.x users

### DIFF
--- a/nap/http.py
+++ b/nap/http.py
@@ -4,7 +4,11 @@ from django.core.exceptions import SuspiciousOperation
 from django.http import HttpResponse, Http404
 from django.utils.encoding import iri_to_uri
 
-from urlparse import urlparse
+try:
+  from urlparse import urlparse
+except ImportError:
+  from urllib.parse import urlparse
+
 try:
     from collections import OrderedDict
 except ImportError:


### PR DESCRIPTION
Note The urlparse module is renamed to urllib.parse in Python 3.0. The 2to3 tool will automatically adapt imports when converting your sources to 3.0.

*Python.org: http://www.python.org/doc//current/library/urlparse.html
