### PR TITLE
Increase testing environment range.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "pypy"
 env:
   - DJANGO=Django==1.4.13
   - DJANGO=Django==1.5.8
@@ -17,3 +19,5 @@ matrix:
   exclude:
     - env: DJANGO=Django==1.4.13
       python: "3.3"
+    - env: DJANGO=Django==1.4.13
+      python: "3.4"

--- a/tox.ini
+++ b/tox.ini
@@ -1,52 +1,65 @@
 [tox]
 envlist =
-    py2.7-d1.3, py2.7-d1.4, py2.7-d1.5, py2.7-d1.6, py2.7-d1.7,
-    py3.3-d1.5, py3.3-d1.6, py3.3-d1.7,
-    py3.4-d1.7
-
+    py27-d1.3, py27-d1.4, py27-d1.5, py27-d1.6, py27-d1.7,
+    py33-d1.5, py33-d1.6, py33-d1.7,
+    py34-d1.5, py34-d1.6, py34-d1.7,
+    pypy-d1.3, pypy-d1.4, pypy-d1.5, pypy-d1.6, pypy-d1.7
 [testenv]
 commands = {envpython} tests/manage.py test nap --settings=settings
 
 
 # Python 2.7
 
-[testenv:py2.7-d1.3]
-basepython = python2.7
+[testenv:py27-d1.3]
 deps = django>=1.3,<1.4
 
-[testenv:py2.7-d1.4]
-basepython = python2.7
+[testenv:py27-d1.4]
 deps = django>=1.4,<1.5
 
-[testenv:py2.7-d1.5]
-basepython = python2.7
+[testenv:py27-d1.5]
 deps = django>=1.5,<1.6
 
-[testenv:py2.7-d1.6]
-basepython = python2.7
+[testenv:py27-d1.6]
 deps = django>=1.6,<1.7
 
-[testenv:py2.7-d1.7]
-basepython = python2.7
+[testenv:py27-d1.7]
 deps = https://www.djangoproject.com/download/1.7c2/tarball/
 
 # Python 3.3
 
-[testenv:py3.3-d1.5]
-basepython = python3.3
+[testenv:py33-d1.5]
 deps = django>=1.5,<1.6
 
-[testenv:py3.3-d1.6]
-basepython = python3.3
+[testenv:py33-d1.6]
 deps = django>=1.6,<1.7
 
-[testenv:py3.3-d1.7]
-basepython = python3.3
+[testenv:py33-d1.7]
 deps = https://www.djangoproject.com/download/1.7c2/tarball/
 
 # Python 3.4
 
-[testenv:py3.4-d1.7]
-basepython = python3.3
+[testenv:py34-d1.5]
+deps = django>=1.5,<1.6
+
+[testenv:py34-d1.6]
+deps = django>=1.6,<1.7
+
+[testenv:py34-d1.7]
 deps = https://www.djangoproject.com/download/1.7c2/tarball/
 
+# Pypy
+
+[testenv:pypy-d1.3]
+deps = django>=1.3,<1.4
+
+[testenv:pypy-d1.4]
+deps = django>=1.4,<1.5
+
+[testenv:pypy-d1.5]
+deps = django>=1.5,<1.6
+
+[testenv:pypy-d1.6]
+deps = django>=1.6,<1.7
+
+[testenv:pypy-d1.7]
+deps = https://www.djangoproject.com/download/1.7c2/tarball/


### PR DESCRIPTION
Adds more python 3.4 environments, and pypy.

Also, if the tox env starts with pyXX, it will automatically use that python.
