### PR TITLE
Fix Django 1.4-1.6 compatibility.

### DIFF
--- a/nap/utils.py
+++ b/nap/utils.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 from cgi import parse_header
 import json
 
-from django.core.handlers.wsgi import ISO_8859_1
+try:
+    from django.core.handlers.wsgi import ISO_8859_1
+except ImportError:  # pre-1.7
+    ISO_8859_1 = str('iso-8859-1')
 
 
 def digattr(obj, attr, default=None):


### PR DESCRIPTION
`django.core.handlers.wsgi.ISO_8859_1` was only added in Django 1.7.
