### PR TITLE
Fix to include mandatory name attribute

### DIFF
--- a/nap/apps.py
+++ b/nap/apps.py
@@ -6,6 +6,8 @@ from django.utils.module_loading import autodiscover_modules
 
 class NapConfig(AppConfig):
     '''App Config that performs auto-discover on ready.'''
+    
+    name = 'nap'
 
     def ready(self):
         super(NapConfig, self).ready()


### PR DESCRIPTION
```
Traceback (most recent call last):
[...]
django.core.exceptions.ImproperlyConfigured: 'nap.apps.NapConfig' must supply a name attribute.
```
