### PR TITLE
rest views fixes

### DIFF
--- a/docs/rest/views.rst
+++ b/docs/rest/views.rst
@@ -3,3 +3,83 @@ Class-Based Views
 =================
 
 Also included are some mixins for working with Django's Class-Based Views.
+
+At a minimum, all of the following mixins require being mixed in to Django's base View.
+
+
+Base Classes
+============
+
+.. class:: MapperMixin
+
+   All of the following classes are based on this.
+
+   .. attribute:: mapper_class
+
+      You must set this to the :class:`DataMapper` to use when processing requests and responses.
+
+
+List Classes
+============
+
+.. class:: ListMixin
+
+   Base list mixin, extends Django's MultipleObjectMixin.
+
+.. class:: ListGetMixin
+
+   Provides ``get()`` for lists.
+
+.. class:: ListPostMixin
+
+   Provides ``post()`` for lists.
+
+
+Single Object Classes
+=====================
+
+.. class:: ObjectMixin
+
+   Base single object mixin, extends Django's SingleObjectMixin.
+
+.. class:: ObjectGetMixin
+
+   Provides ``get()`` for single objects.
+
+.. class:: ObjectPutMixin
+
+   Provides ``put()`` for single objects.
+
+.. class:: ObjectPatchMixin
+
+   Provides ``patch()`` for single objects.
+
+.. class:: ObjectDeleteMixin
+
+   Provides ``delete()`` for single objects.
+
+
+Example
+-------
+
+Sample ``views.py`` that provides ``GET``, ``PUT``, ``PATCH``, and ``DELETE`` methods for the Poll model:
+
+.. code-block:: python
+
+   from django.views.generic import View
+
+   from nap.datamapper.models import ModelDataMapper
+   from nap.rest.views import ObjectGetMixin, ObjectPutMixin, ObjectPatchMixin, ObjectDeleteMixin, ObjectMixin
+
+   from .models import Poll
+
+
+   class PollMapper(ModelDataMapper):
+       class Meta:
+           model = Poll
+           fields = ['question', 'pub_date']
+
+
+   class SinglePollView(ObjectGetMixin, ObjectPutMixin, ObjectPatchMixin, ObjectDeleteMixin, ObjectMixin, View):
+       model = Poll
+       mapper_class = PollMapper

--- a/nap/rest/views.py
+++ b/nap/rest/views.py
@@ -29,7 +29,7 @@ class MapperMixin(JsonMixin):
     ok_status = http.STATUS.OK
     accepted_status = http.STATUS.ACCEPTED
     created_status = http.STATUS.CREATED
-    deleted_status = http.STATUS.RESET_CONTENT
+    deleted_status = http.STATUS.NO_CONTENT
     error_status = http.STATUS.BAD_REQUEST
 
     def get_mapper(self, obj=None):
@@ -125,7 +125,7 @@ class ObjectPutMixin(object):
         self.data = self.get_request_data({})
 
         try:
-            self.mapper._patch(self.data)
+            self.mapper._apply(self.data)
         except ValidationError as e:
             return self.put_invalid(e.error_dict)
 
@@ -136,6 +136,29 @@ class ObjectPutMixin(object):
         return self.ok_response()
 
     def put_invalid(self, errors):
+        return self.error_response(errors)
+
+
+class ObjectPatchMixin(object):
+
+    def patch(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.mapper = self.get_mapper(self.object)
+
+        self.data = self.get_request_data({})
+
+        try:
+            self.mapper._patch(self.data)
+        except ValidationError as e:
+            return self.patch_invalid(e.error_dict)
+
+        return self.patch_valid()
+
+    def patch_valid(self):
+        self.object.save()
+        return self.ok_response()
+
+    def patch_invalid(self, errors):
         return self.error_response(errors)
 
 

--- a/tests/rest_views.py
+++ b/tests/rest_views.py
@@ -1,0 +1,17 @@
+from django.views.generic import View
+
+from nap.datamapper.models import ModelDataMapper
+from nap.rest import views
+
+from .models import Poll
+
+
+class PollMapper(ModelDataMapper):
+    class Meta:
+        model = Poll
+        fields = ['question', 'pub_date']
+
+
+class SinglePollView(views.ObjectGetMixin, views.ObjectPutMixin, views.ObjectPatchMixin, views.ObjectDeleteMixin, views.ObjectMixin, View):
+    model = Poll
+    mapper_class = PollMapper

--- a/tests/tests/test_rest_views.py
+++ b/tests/tests/test_rest_views.py
@@ -1,0 +1,89 @@
+from django.test import TestCase, Client
+import json
+from nap.http import STATUS
+
+from ..models import Poll
+
+
+class SingleObjectRestViewTest(TestCase):
+
+    def setUp(self):
+        self.c = Client()
+        self.default_question = 'Default question'
+        self.default_pub_date = '2015-01-01 00:00:00'
+        self.poll = Poll.objects.create(question=self.default_question, pub_date=self.default_pub_date)
+
+    def test_get(self):
+        response = self.c.get('/rest/polls/{}'.format(self.poll.pk))
+        self.assertEqual(response.status_code, STATUS.OK)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data['question'], self.default_question)
+        self.assertEqual(data['pub_date'], self.default_pub_date)
+
+    def test_put(self):
+        # put requires all fields
+        request_data = {}
+        response = self.c.put('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.BAD_REQUEST)
+
+        request_data = {'question': 'A new question'}
+        response = self.c.put('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.BAD_REQUEST)
+
+        request_data = {'pub_date': '2014-06-01 12:30:30'}
+        response = self.c.put('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.BAD_REQUEST)
+
+        request_data = {'question': 'A new question', 'pub_date': '2014-06-01 12:30:30'}
+        response = self.c.put('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.OK)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data, request_data)
+        # reload poll from db and see that it's updated
+        poll = Poll.objects.get(pk=self.poll.pk)
+        self.assertEqual(poll.question, request_data['question'])
+        self.assertEqual(poll.pub_date.isoformat(' '), request_data['pub_date'])
+
+    def test_patch(self):
+        # patch can have any combination of fields
+        request_data = {}
+        response = self.c.patch('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.OK)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data, {'question': self.default_question, 'pub_date': self.default_pub_date})
+        # reload poll from db and see that it's updated
+        poll = Poll.objects.get(pk=self.poll.pk)
+        self.assertEqual(poll.question, self.default_question)
+        self.assertEqual(poll.pub_date.isoformat(' '), self.default_pub_date)
+
+        # one field
+        request_data = {'question': 'One field question'}
+        response = self.c.patch('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.OK)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data, {'question': request_data['question'], 'pub_date': self.default_pub_date})
+        # reload poll from db and see that it's updated
+        poll = Poll.objects.get(pk=self.poll.pk)
+        self.assertEqual(poll.question, request_data['question'])
+        self.assertEqual(poll.pub_date.isoformat(' '), self.default_pub_date)
+
+        request_data = {'question': 'A new question', 'pub_date': '2014-06-01 12:30:30'}
+        response = self.c.patch('/rest/polls/{}'.format(self.poll.pk), data=json.dumps(request_data), content_type='application/json')
+        self.assertEqual(response.status_code, STATUS.OK)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(data, request_data)
+        # reload poll from db and see that it's updated
+        poll = Poll.objects.get(pk=self.poll.pk)
+        self.assertEqual(poll.question, request_data['question'])
+        self.assertEqual(poll.pub_date.isoformat(' '), request_data['pub_date'])
+
+    def test_delete(self):
+        response = self.c.delete('/rest/polls/{}'.format(self.poll.pk))
+        self.assertEqual(response.status_code, STATUS.NO_CONTENT)
+        # make sure the poll isn't in the db
+        self.assertFalse(Poll.objects.filter(pk=self.poll.pk).exists())

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, include
 from . import rpc_views
+from . import rest_views
 
 #from nap.rest import api
 #api.autodiscover()
@@ -7,4 +8,5 @@ from . import rpc_views
 urlpatterns = patterns('',
 #    (r'^api/', include(api.patterns(True))),
     (r'^rpc/', rpc_views.View.as_view()),
+    (r'^rest/polls/(?P<pk>\d+)$', rest_views.SinglePollView.as_view()),
 )


### PR DESCRIPTION
This PR is for #52.

Changes:

- `ObjectPutMixin` uses `mapper._apply()` instead of `mapper._patch()` to have proper PUT behavior
- New class `ObjectPatchMixin` which provides a `patch()` method for mixing into class-based views; uses `mapper._patch()`
- `MapperMixin.deleted_status` is NO CONTENT (204) instead of RESET CONTENT (205)

Tests for all single-object mixins and docs for rest views added.