### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ django-nap
 [![Version](https://pypip.in/v/django-nap/badge.png)](https://crate.io/package/django-nap)
 [![Build Status](https://secure.travis-ci.org/funkybob/django-nap.png?branch=master)](http://travis-ci.org/funkybob/django-nap)
 
-Read The Docs: http://django-nap.readthedocs.org/en/latest/
+Read The Docs: https://django-nap.readthedocs.io/en/latest/
 
-Change log: http://django-nap.readthedocs.org/en/latest/changelog.html
+Change log: https://django-nap.readthedocs.io/en/latest/changelog.html
 
 An API library for Django
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.