### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/extras/http.rst
+++ b/docs/extras/http.rst
@@ -108,7 +108,7 @@ HttpResponse.  This is a personal preference, in that typically you'd use:
 except_response
 ---------------
 
-In case you want to use these raiseable responses in your own views, Nap
+In case you want to use these raisable responses in your own views, Nap
 provides a `except_response` decorator.
 
 .. code-block:: python

--- a/docs/mapper/fields.rst
+++ b/docs/mapper/fields.rst
@@ -74,7 +74,7 @@ Accessing extra state
 
 Sometimes when serialising an object, you need to provide additional state.
 This can be done using a ``context_field``, which subclasses ``field``, but
-passes any extra ``kwargs`` that were pased to `Mapper` instance `context` to
+passes any extra ``kwargs`` that were passed to `Mapper` instance `context` to
 the getter and setter methods as an extra argument.
 
 .. class:: context_field()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quick Start
 ===========
 
-Nap REST views work by combining Mappers with composible Class-Based Views.
+Nap REST views work by combining Mappers with composable Class-Based Views.
 
 Let's see how you might got about providng an API for the Poll example from the
 Django tutorial.

--- a/docs/tutorial/mapper.rst
+++ b/docs/tutorial/mapper.rst
@@ -721,7 +721,7 @@ leverage Django's build in authentication mixins to control access.
 
 We've decided we only want to allow logged in users to post new messages, so we
 mix in the `UserPassesTestMixin` to the ListListView class.  All we need is to
-add a `test_func` to only check if a user is authentencated if it's a POST.
+add a `test_func` to only check if a user is authenticated if it's a POST.
 
 .. code-block:: python
 

--- a/docs/tutorial/mappers.rst
+++ b/docs/tutorial/mappers.rst
@@ -141,7 +141,7 @@ stored on the Mapper instance as ``_errors``.
 Readonly fields
 ---------------
 
-But wait!  We don't want to let people alter the Question a Choice is assignd
+But wait!  We don't want to let people alter the Question a Choice is assigned
 to!
 
 We need to mark that field as read only.

--- a/docs/tutorial/views.rst
+++ b/docs/tutorial/views.rst
@@ -26,7 +26,7 @@ definitions for list and object views:
         mapper_class = mappers.QuestionMapper
 
 Next we'll define our ``QuestionListView``, based on this and the
-``ListBaseView`` fron nap:
+``ListBaseView`` from nap:
 
 .. code-block:: python
    :caption: polls/views.py

--- a/src/nap/rpc/views.py
+++ b/src/nap/rpc/views.py
@@ -16,7 +16,7 @@ def method(view):
 
 
 def is_rpc_method(m):
-    '''Helper for checking if something is marked as a pubishable method.'''
+    '''Helper for checking if something is marked as a punishable method.'''
     return getattr(m, RPC_MARKER, False)
 
 

--- a/src/nap/rpc/views.py
+++ b/src/nap/rpc/views.py
@@ -16,7 +16,7 @@ def method(view):
 
 
 def is_rpc_method(m):
-    '''Helper for checking if something is marked as a punishable method.'''
+    '''Helper for checking if something is marked as a publishable method.'''
     return getattr(m, RPC_MARKER, False)
 
 


### PR DESCRIPTION
There are small typos in:
- docs/extras/http.rst
- docs/mapper/fields.rst
- docs/quickstart.rst
- docs/tutorial/mapper.rst
- docs/tutorial/mappers.rst
- docs/tutorial/views.rst
- src/nap/rpc/views.py

Fixes:
- Should read `raisable` rather than `raiseable`.
- Should read `publishable` rather than `pubishable`.
- Should read `passed` rather than `pased`.
- Should read `from` rather than `fron`.
- Should read `composable` rather than `composible`.
- Should read `authenticated` rather than `authentencated`.
- Should read `assigned` rather than `assignd`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md